### PR TITLE
Retrieve MarkPanels from DCS and add to database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,16 @@ FodyWeavers.xsd
 # Do not include any of the configurations
 configuration*.yaml
 
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/DCScribe/bin/Debug/net7.0/win-x64/DCScribe.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/DCScribe",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/DCScribe/DCScribe.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/DCScribe/DCScribe.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/DCScribe/DCScribe.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/DCScribe.Grpc/RpcClient.cs
+++ b/DCScribe.Grpc/RpcClient.cs
@@ -130,5 +130,37 @@ namespace RurouniJones.DCScribe.Grpc
                 return airbases;
             }
         }
+
+        public async Task<List<MarkPanel>> GetMarkPanelsAsync()
+        {
+            using var channel = GrpcChannel.ForAddress($"http://{HostName}:{Port}");
+            var client = new WorldService.WorldServiceClient(channel);
+
+            var markPanels = new List<MarkPanel>();
+            try
+            {
+                var response = await client.GetMarkPanelsAsync(new GetMarkPanelsRequest());
+
+                foreach (var markpanel in response.MarkPanels)
+                {
+                    markPanels.Add(new MarkPanel
+                    {
+                        Id = markpanel.Id,
+                        Time = markpanel.Time,
+                        Position = new Position(markpanel.Position.Lat, markpanel.Position.Lon),
+                        Text = markpanel.Text,
+                        Coalition = markpanel.HasCoalition ? (int) markpanel.Coalition : -1
+                    });
+                }
+
+                return markPanels;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "gRPC Exception");
+                return markPanels;
+            }
+        }
+
     }
 }

--- a/DCScribe.Postgres/DCScribe.Postgres.csproj
+++ b/DCScribe.Postgres/DCScribe.Postgres.csproj
@@ -28,5 +28,8 @@
 		<None Update="Documentation\DatabaseScripts\CreateUnits.pgsql">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="Documentation\DatabaseScripts\CreateMarkPanels.pgsql">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 </Project>

--- a/DCScribe.Postgres/Documentation/DatabaseScripts/CreateMarkPanels.pgsql
+++ b/DCScribe.Postgres/Documentation/DatabaseScripts/CreateMarkPanels.pgsql
@@ -1,0 +1,19 @@
+-- Table: public.markpanels
+
+-- DROP TABLE public.markpanels;
+
+CREATE TABLE IF NOT EXISTS public.markpanels
+(
+    "id" integer NOT NULL,
+	time double precision NOT NULL DEFAULT 0,
+    "position" geography NOT NULL,
+    "text" text COLLATE pg_catalog."default" NOT NULL,
+    coalition int NOT NULL DEFAULT -1,
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT markpanels_pkey PRIMARY KEY ("id")
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE public.markpanels
+    OWNER to dcscribe;

--- a/DCScribe.Shared/Interfaces/IDatabaseClient.cs
+++ b/DCScribe.Shared/Interfaces/IDatabaseClient.cs
@@ -19,10 +19,14 @@ namespace RurouniJones.DCScribe.Shared.Interfaces
 
         Task TruncateAirbasesAsync();
 
+        Task TruncateMarkPanelsAsync();
+
         Task UpdateUnitsAsync(List<Unit> units, CancellationToken scribeToken);
 
         Task DeleteUnitsAsync(List<uint> units, CancellationToken scribeToken);
 
         Task WriteAirbasesAsync(List<Airbase> airbases, CancellationToken scribeToken);
+
+        Task WriteMarkPanelsAsync(List<MarkPanel> markpanels, CancellationToken scribeToken);
     }
 }

--- a/DCScribe.Shared/Interfaces/IRpcClient.cs
+++ b/DCScribe.Shared/Interfaces/IRpcClient.cs
@@ -28,5 +28,7 @@ namespace RurouniJones.DCScribe.Shared.Interfaces
         Task StreamUnitsAsync(CancellationToken stoppingToken);
 
         Task<List<Airbase>> GetAirbasesAsync();
+
+        Task<List<MarkPanel>> GetMarkPanelsAsync();
     }
 }

--- a/DCScribe.Shared/Models/MarkPanel.cs
+++ b/DCScribe.Shared/Models/MarkPanel.cs
@@ -1,0 +1,15 @@
+using RurouniJones.DCScribe.Shared.Interfaces;
+
+namespace RurouniJones.DCScribe.Shared.Models
+{
+    public class MarkPanel
+    {
+        public uint Id { get; init; }
+        public double Time { get; init; }
+        public Position Position { get; init; }
+        public string Text { get; init; }
+        public Unit Initiator { get; init; }
+        public int Coalition { get; init; }
+        public int GroupId { get; init; }
+    }
+}


### PR DESCRIPTION
The only processing of the DCS data before sending to DB is checking for the existence of a coalition member and passing a -1 if the member is not present.
The timer for the new ProcessMarkPanelUpdates task is currently set at 900 seconds.