### PR TITLE
Add new config settings for task timers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,6 +363,7 @@ FodyWeavers.xsd
 
 # Do not include any of the configurations
 configuration*.yaml
+!configuration.[Ss]ample.yaml
 
 
 .vscode/*

--- a/DCScribe.Grpc/RpcClient.cs
+++ b/DCScribe.Grpc/RpcClient.cs
@@ -27,7 +27,7 @@ namespace RurouniJones.DCScribe.Grpc
             _logger = logger;
         }
 
-        public async Task StreamUnitsAsync(CancellationToken stoppingToken)
+        public async Task StreamUnitsAsync(uint pollRate, CancellationToken stoppingToken)
         {
             using var channel = GrpcChannel.ForAddress($"http://{HostName}:{Port}");
             var client = new MissionService.MissionServiceClient(channel);
@@ -35,7 +35,7 @@ namespace RurouniJones.DCScribe.Grpc
             {
                 var units = client.StreamUnits(new StreamUnitsRequest
                 {
-                    PollRate = 1,
+                    PollRate = pollRate,
                     MaxBackoff = 30
                 }, null, null, stoppingToken);
                 await foreach (var update in units.ResponseStream.ReadAllAsync(stoppingToken))

--- a/DCScribe.Postgres/DCScribe.Postgres.csproj
+++ b/DCScribe.Postgres/DCScribe.Postgres.csproj
@@ -31,5 +31,8 @@
 		<None Update="Documentation\DatabaseScripts\CreateMarkPanels.pgsql">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="Documentation\configuration.Sample.yaml">
+      		<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    	</None>
 	</ItemGroup>
 </Project>

--- a/DCScribe.Postgres/Documentation/configuration.Sample.yaml
+++ b/DCScribe.Postgres/Documentation/configuration.Sample.yaml
@@ -42,13 +42,16 @@ GameServers:
       Host: rbs.example.com
       # This is the default port, change it if you have changed the server-side one
       Port: 50051
-    # Enable/disable the various DCScribe tasks and set task properties e.g. time between queries
+    # Enable/disable the various DCScribe tasks and set task properties e.g. time between queries. 
+    # All time values are in seconds
     Tasks:
-      # Stream the units in the mission running on the DCS server
+      # Record positions of units in the mission running on the DCS server. 
+      # The Timer value determines how often the unit positions are written to the database. 
+      # For best accuracy have the PollRate be half of the timer (rounded down since uint). 
       RecordUnitPositions:
         Enabled: true
-        PollRate: 5
-        Timer: 4
+        PollRate: 2
+        Timer: 5
       # Query the DCS server for a list of the airbases in the running mission
       ProcessAirbaseUpdates:
         Enabled: true
@@ -71,11 +74,10 @@ GameServers:
     Rpc:
       Host: rws.example.com
       Port: 50051
-    UnitStream: false
     Tasks:
       RecordUnitPositions:
         Enabled: true
-        PollRate: 10
+        PollRate: 1
         Timer: 2
       ProcessAirbaseUpdates:
         Enabled: true

--- a/DCScribe.Postgres/Documentation/configuration.Sample.yaml
+++ b/DCScribe.Postgres/Documentation/configuration.Sample.yaml
@@ -42,15 +42,20 @@ GameServers:
       Host: rbs.example.com
       # This is the default port, change it if you have changed the server-side one
       Port: 50051
-    # Enable or disable the unit stream
-    UnitStream: true
-    # Set the time in seconds between task runs
-    TaskTimers:
-      - # Query the DCS server for a list of the airbases in the running mission
-        TaskName: ProcessAirbaseUpdates
+    # Enable/disable the various DCScribe tasks and set task properties e.g. time between queries
+    Tasks:
+      # Stream the units in the mission running on the DCS server
+      RecordUnitPositions:
+        Enabled: true
+        PollRate: 5
+        Timer: 4
+      # Query the DCS server for a list of the airbases in the running mission
+      ProcessAirbaseUpdates:
+        Enabled: true
         Timer: 60
-      - # Query the DCS server for a list of the map marks in the running mission
-        TaskName: ProcessMarkPanelUpdates
+      # Query the DCS server for a list of the map marks in the running mission
+      ProcessMarkPanelUpdates:
+        Enabled: true
         Timer: 120
   # You can specify multiple game servers and have one DCScribe instance handle all of them
   # This section configures a second server. Delete everything below this line to remove.
@@ -67,10 +72,14 @@ GameServers:
       Host: rws.example.com
       Port: 50051
     UnitStream: false
-    TaskTimers:
-      - 
-        TaskName: ProcessAirbaseUpdates
+    Tasks:
+      RecordUnitPositions:
+        Enabled: true
+        PollRate: 10
+        Timer: 2
+      ProcessAirbaseUpdates:
+        Enabled: true
         Timer: 90
-      - 
-        TaskName: ProcessMarkPanelUpdates
+      ProcessMarkPanelUpdates:
+        Enabled: true
         Timer: 180

--- a/DCScribe.Postgres/Documentation/configuration.Sample.yaml
+++ b/DCScribe.Postgres/Documentation/configuration.Sample.yaml
@@ -1,0 +1,76 @@
+---
+# The following setup is for the logging system. For information on how to change this
+# and what other options are available see https://serilog.net/
+Serilog:
+  Using:
+    - Serilog.Sinks.File
+  MinimumLevel: 
+    Default: Information
+  Override: 
+    Microsoft: Warning
+    System: Warning
+  Enrich:
+    - FromLogContext
+    - WithProcessId
+    - WithThreadId
+  WriteTo:
+    - 
+      Name: File
+      Args:
+        path: logs/dcscribe.log
+# This is the configuration for each DCS GameServer. This Sample configuration contains
+# configuration for two separate servers. Edit the configuration below, including adding
+# or removing servers, to suit your setup.
+GameServers:
+  - # These dashes indicate a configuration record for a new GameServer
+    # Replace the following example fields with those used by your server and database
+    Name: RurouniJones Bestest Server
+    # Used in logging
+    ShortName: RBS
+    Database:
+      # Make sure you set your pg_hba.conf file if you are not connecting over localhost
+      # https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+      Host: rbs.example.com
+      Port: 5432
+      Name: rbs_database
+      Username: dcscribe
+      Password: this_is_a_password
+    # This is the configuration for connecting to the DCS-gRPC server
+    Rpc:
+      # Because DCS-gRPC runs inside the DCS process this should be your DCS server hostname
+      # or IP address
+      Host: rbs.example.com
+      # This is the default port, change it if you have changed the server-side one
+      Port: 50051
+    # Enable or disable the unit stream
+    UnitStream: true
+    # Set the time in seconds between task runs
+    TaskTimers:
+      - # Query the DCS server for a list of the airbases in the running mission
+        TaskName: ProcessAirbaseUpdates
+        Timer: 60
+      - # Query the DCS server for a list of the map marks in the running mission
+        TaskName: ProcessMarkPanelUpdates
+        Timer: 120
+  # You can specify multiple game servers and have one DCScribe instance handle all of them
+  # This section configures a second server. Delete everything below this line to remove.
+  - 
+    Name: RurouniJones Worstest Server
+    ShortName: RWS
+    Database:
+      Host: rws.example.com
+      Port: 5432
+      Name: rws_database
+      Username: dcscribe
+      Password: this_is_a_password
+    Rpc:
+      Host: rws.example.com
+      Port: 50051
+    UnitStream: false
+    TaskTimers:
+      - 
+        TaskName: ProcessAirbaseUpdates
+        Timer: 90
+      - 
+        TaskName: ProcessMarkPanelUpdates
+        Timer: 180

--- a/DCScribe.Shared/Interfaces/IRpcClient.cs
+++ b/DCScribe.Shared/Interfaces/IRpcClient.cs
@@ -25,7 +25,7 @@ namespace RurouniJones.DCScribe.Shared.Interfaces
          */
         public int Port { get; set; }
 
-        Task StreamUnitsAsync(CancellationToken stoppingToken);
+        Task StreamUnitsAsync(uint pollRate, CancellationToken stoppingToken);
 
         Task<List<Airbase>> GetAirbasesAsync();
 

--- a/DCScribe/Core/Configuration.cs
+++ b/DCScribe/Core/Configuration.cs
@@ -13,6 +13,8 @@ namespace RurouniJones.DCScribe.Core
         public string ShortName { get; set; }
         public Database Database { get; set; }
         public Rpc Rpc { get; set; }
+        public List<TaskTimer> TaskTimers { get;set; }
+        public bool UnitStream { get; set; }
     }
 
     public sealed class Database
@@ -28,5 +30,12 @@ namespace RurouniJones.DCScribe.Core
     {
         public string Host { get; set; }
         public int Port { get; set; }
+    }
+
+    public sealed class TaskTimer
+    {
+        public string TaskName { get;set; }
+        public int Timer { get;set; }
+        
     }
 }

--- a/DCScribe/Core/Configuration.cs
+++ b/DCScribe/Core/Configuration.cs
@@ -13,8 +13,7 @@ namespace RurouniJones.DCScribe.Core
         public string ShortName { get; set; }
         public Database Database { get; set; }
         public Rpc Rpc { get; set; }
-        public List<TaskTimer> TaskTimers { get;set; }
-        public bool UnitStream { get; set; }
+        public Tasks Tasks { get;set; }
     }
 
     public sealed class Database
@@ -32,10 +31,28 @@ namespace RurouniJones.DCScribe.Core
         public int Port { get; set; }
     }
 
-    public sealed class TaskTimer
+    public sealed class Tasks
     {
-        public string TaskName { get;set; }
+        public RecordUnitPositions RecordUnitPositions { get;set; }
+        public ProcessAirbaseUpdates ProcessAirbaseUpdates { get;set; }
+        public ProcessMarkPanelUpdates ProcessMarkPanelUpdates { get;set; }
+    }
+    public sealed class RecordUnitPositions
+    {
+        public bool Enabled { get;set; }
+        public uint PollRate { get;set; }
+        public int Timer { get;set; }      
+    }
+
+    public sealed class ProcessAirbaseUpdates
+    {
+        public bool Enabled { get;set; }
+        public int Timer { get;set; }        
+    }
+
+    public sealed class ProcessMarkPanelUpdates
+    {
+        public bool Enabled { get;set; }
         public int Timer { get;set; }
-        
     }
 }

--- a/DCScribe/Core/Scribe.cs
+++ b/DCScribe/Core/Scribe.cs
@@ -74,7 +74,8 @@ namespace RurouniJones.DCScribe.Core
                         */
                         var queue = new ConcurrentQueue<Unit>();
                         _rpcClient.UpdateQueue = queue;
-                        tasks.Add(_rpcClient.StreamUnitsAsync(GameServer.Tasks.RecordUnitPositions.PollRate, scribeToken)); // Get the events and put them into the queue
+                        var pollRate = GameServer.Tasks.RecordUnitPositions.PollRate;
+                        tasks.Add(_rpcClient.StreamUnitsAsync(pollRate, scribeToken)); // Get the events and put them into the queue
                         tasks.Add(ProcessUnitQueue(queue, scribeToken)); // Process the queue events into the units dictionary
                 }
                 await Task.WhenAny(tasks); // If one task finishes (usually when the RPC client gets


### PR DESCRIPTION
Allows per server timers (in seconds) for the airbase and markpanel tasks as well as a boolean flag to enable/disable the unit stream.