### PR TITLE
Subtract 1 frm airbase category before enum lookup

### DIFF
--- a/DCScribe.Grpc/RpcClient.cs
+++ b/DCScribe.Grpc/RpcClient.cs
@@ -115,7 +115,7 @@ namespace RurouniJones.DCScribe.Grpc
                         Callsign = airbase.Callsign,
                         Position = new Position(airbase.Position.Lat, airbase.Position.Lon),
                         Altitude = airbase.Position.Alt,
-                        Category = (Airbase.AirbaseCategory) (int) airbase.Category,
+                        Category = (Airbase.AirbaseCategory) (int) airbase.Category - 1,
                         Type = airbase.DisplayName, // "Invisible FARP", "CG Ticonderoga", "Krymsk" etc.
                         Coalition =  (int) airbase.Coalition,
                         Symbology = new MilStd2525d((int) airbase.Coalition, null) // TODO Think about how to do this. Probably based off Category


### PR DESCRIPTION
The grpc enum for airbases is 1-based while the DCS(cribe) enum is 0-based, so the value needs to be re-aligned before doing the lookup by subtracting 1.